### PR TITLE
Refactor UIColor Extensions

### DIFF
--- a/ThunderCats/UIColor+TCAdditions.h
+++ b/ThunderCats/UIColor+TCAdditions.h
@@ -49,4 +49,13 @@
  */
 - (BOOL)tc_isEqualToColor:(UIColor * __tc_nonnull)aColor;
 
+/**
+ *  Returns a Boolean value that indicates whether a given hex string is a valid hex string.
+ *
+ *  @param hex string to be validated.
+ *
+ *  @return YES if hex string is a valid hex string, otherwise NO.
+ */
++ (BOOL)tc_isValidHexString:(NSString * __tc_nonnull)hexString;
+
 @end

--- a/ThunderCats/UIColor+TCAdditions.m
+++ b/ThunderCats/UIColor+TCAdditions.m
@@ -54,10 +54,10 @@
                      [hexString substringWithRange:NSMakeRange(0, 1)], [hexString substringWithRange:NSMakeRange(0, 1)],
                      [hexString substringWithRange:NSMakeRange(1, 1)], [hexString substringWithRange:NSMakeRange(1, 1)],
                      [hexString substringWithRange:NSMakeRange(2, 1)], [hexString substringWithRange:NSMakeRange(2, 1)],
-                     [hexString substringWithRange:NSMakeRange(3, 2)], [hexString substringWithRange:NSMakeRange(3, 2)]];
+                     [hexString substringWithRange:NSMakeRange(3, 1)], [hexString substringWithRange:NSMakeRange(3, 1)]];
     }
     
-    if ([hexString length] == 6 || [hexString length] == 8)
+    if ([hexString length] == 6)
     {
         hexString = [hexString stringByAppendingString:@"ff"];
     }
@@ -87,7 +87,7 @@
         hexString = [hexString substringFromIndex:1];
     }
     
-    NSCharacterSet *validCharacters = [NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEFabcdefg"];
+    NSCharacterSet *validCharacters = [NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEFabcdef"];
     
     bool invalidCharacters = ![[hexString stringByTrimmingCharactersInSet:validCharacters]  isEqualToString: @""];
     bool invalidLength = [hexString length] != 3 && [hexString length] != 4 && [hexString length] != 6 && [hexString length] != 8;

--- a/ThunderCats/UIColor+TCAdditions.m
+++ b/ThunderCats/UIColor+TCAdditions.m
@@ -34,20 +34,12 @@
 
 + (UIColor *)tc_colorWithHexString:(NSString *)hexString
 {
-    if([hexString hasPrefix:@"#"])
-    {
-        hexString = [hexString substringFromIndex:1];
-    }
-    
-    NSCharacterSet *validCharacters = [NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEFabcdefg"];
-    
-    bool invalidLength = [hexString length] != 3 && [hexString length] != 6;
-    bool invalidCharacters = ![[hexString stringByTrimmingCharactersInSet:validCharacters]  isEqualToString: @""];
-
-    if (invalidLength || invalidCharacters)
+    if (![UIColor tc_isValidHexString: hexString])
     {
         [TCInvalidArgument raiseWithReason:[NSString stringWithFormat:@"%@ is not a valid hex string.", hexString]];
     }
+    
+    hexString = [hexString stringByReplacingOccurrencesOfString:@"#" withString:@""];
     
     if ([hexString length] == 3)
     {
@@ -56,8 +48,16 @@
                        [hexString substringWithRange:NSMakeRange(1, 1)], [hexString substringWithRange:NSMakeRange(1, 1)],
                        [hexString substringWithRange:NSMakeRange(2, 1)], [hexString substringWithRange:NSMakeRange(2, 1)]];
     }
+    else if ([hexString length] == 4)
+    {
+        hexString = [NSString stringWithFormat:@"%@%@%@%@%@%@%@%@",
+                     [hexString substringWithRange:NSMakeRange(0, 1)], [hexString substringWithRange:NSMakeRange(0, 1)],
+                     [hexString substringWithRange:NSMakeRange(1, 1)], [hexString substringWithRange:NSMakeRange(1, 1)],
+                     [hexString substringWithRange:NSMakeRange(2, 1)], [hexString substringWithRange:NSMakeRange(2, 1)],
+                     [hexString substringWithRange:NSMakeRange(3, 2)], [hexString substringWithRange:NSMakeRange(3, 2)]];
+    }
     
-    if ([hexString length] == 6)
+    if ([hexString length] == 6 || [hexString length] == 8)
     {
         hexString = [hexString stringByAppendingString:@"ff"];
     }
@@ -77,6 +77,22 @@
 - (BOOL)tc_isEqualToColor:(UIColor *)aColor
 {
     return CGColorEqualToColor(self.CGColor, aColor.CGColor);
+}
+
+
++ (BOOL)tc_isValidHexString:(NSString *)hexString
+{
+    if([hexString hasPrefix:@"#"])
+    {
+        hexString = [hexString substringFromIndex:1];
+    }
+    
+    NSCharacterSet *validCharacters = [NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEFabcdefg"];
+    
+    bool invalidCharacters = ![[hexString stringByTrimmingCharactersInSet:validCharacters]  isEqualToString: @""];
+    bool invalidLength = [hexString length] != 3 && [hexString length] != 4 && [hexString length] != 6 && [hexString length] != 8;
+
+    return !(invalidLength || invalidCharacters);
 }
 
 @end

--- a/ThunderCats/UIColor+TCAdditions.m
+++ b/ThunderCats/UIColor+TCAdditions.m
@@ -34,28 +34,36 @@
 
 + (UIColor *)tc_colorWithHexString:(NSString *)hexString
 {
-    NSString *cleanString = [hexString stringByReplacingOccurrencesOfString:@"#" withString:@""];
-    
-    if ([cleanString length] != 3 && [cleanString length] != 6)
+    if([hexString hasPrefix:@"#"])
     {
-        [TCInvalidArgument raiseWithReason:@"invalid hex string"];
+        hexString = [hexString substringFromIndex:1];
     }
     
-    if ([cleanString length] == 3)
+    NSCharacterSet *validCharacters = [NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEFabcdefg"];
+    
+    bool invalidLength = [hexString length] != 3 && [hexString length] != 6;
+    bool invalidCharacters = ![[hexString stringByTrimmingCharactersInSet:validCharacters]  isEqualToString: @""];
+
+    if (invalidLength || invalidCharacters)
     {
-        cleanString = [NSString stringWithFormat:@"%@%@%@%@%@%@",
-                       [cleanString substringWithRange:NSMakeRange(0, 1)], [cleanString substringWithRange:NSMakeRange(0, 1)],
-                       [cleanString substringWithRange:NSMakeRange(1, 1)], [cleanString substringWithRange:NSMakeRange(1, 1)],
-                       [cleanString substringWithRange:NSMakeRange(2, 1)], [cleanString substringWithRange:NSMakeRange(2, 1)]];
+        [TCInvalidArgument raiseWithReason:[NSString stringWithFormat:@"%@ is not a valid hex string.", hexString]];
     }
     
-    if ([cleanString length] == 6)
+    if ([hexString length] == 3)
     {
-        cleanString = [cleanString stringByAppendingString:@"ff"];
+        hexString = [NSString stringWithFormat:@"%@%@%@%@%@%@",
+                       [hexString substringWithRange:NSMakeRange(0, 1)], [hexString substringWithRange:NSMakeRange(0, 1)],
+                       [hexString substringWithRange:NSMakeRange(1, 1)], [hexString substringWithRange:NSMakeRange(1, 1)],
+                       [hexString substringWithRange:NSMakeRange(2, 1)], [hexString substringWithRange:NSMakeRange(2, 1)]];
+    }
+    
+    if ([hexString length] == 6)
+    {
+        hexString = [hexString stringByAppendingString:@"ff"];
     }
     
     unsigned int baseValue;
-    [[NSScanner scannerWithString:cleanString] scanHexInt:&baseValue];
+    [[NSScanner scannerWithString:hexString] scanHexInt:&baseValue];
     
     float red = ((baseValue >> 24) & 0xFF) / 255.0f;
     float green = ((baseValue >> 16) & 0xFF) / 255.0f;

--- a/ThunderCats/UIColor+TCAdditions.m
+++ b/ThunderCats/UIColor+TCAdditions.m
@@ -28,12 +28,19 @@
 
 
 #import "UIColor+TCAdditions.h"
+#import "TCInvalidArgument.h"
 
 @implementation UIColor (TCAdditions)
 
 + (UIColor *)tc_colorWithHexString:(NSString *)hexString
 {
     NSString *cleanString = [hexString stringByReplacingOccurrencesOfString:@"#" withString:@""];
+    
+    if ([cleanString length] != 3 && [cleanString length] != 6)
+    {
+        [TCInvalidArgument raiseWithReason:@"invalid hex string"];
+    }
+    
     if ([cleanString length] == 3)
     {
         cleanString = [NSString stringWithFormat:@"%@%@%@%@%@%@",
@@ -58,14 +65,10 @@
     return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
 }
 
+
 - (BOOL)tc_isEqualToColor:(UIColor *)aColor
 {
-    CGFloat r1, g1, b1, a1, r2, g2, b2, a2;
-    
-    [self getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-    [aColor getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-    
-    return r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2==0;
+    return CGColorEqualToColor(self.CGColor, aColor.CGColor);
 }
 
 @end

--- a/ThunderCatsTests/UIColorTests.m
+++ b/ThunderCatsTests/UIColorTests.m
@@ -58,6 +58,24 @@
     XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.001,  @"Expected blue value of 0, but got %f", blue);
     XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
+    blackColor = [UIColor tc_colorWithHexString:@"#00000080"];
+    
+    [blackColor getRed:&red green:&green blue:&blue alpha:&alpha];
+    
+    XCTAssertEqualWithAccuracy(red, 0.0/255.0, 0.001,  @"Expected red value of 0, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.001,  @"Expected green value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.001,  @"Expected blue value of 0, but got %f", blue);
+    XCTAssertEqualWithAccuracy(floor(alpha * 100)/100, 0.50, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
+    
+    blackColor = [UIColor tc_colorWithHexString:@"#FFFF00cc"];
+    
+    [blackColor getRed:&red green:&green blue:&blue alpha:&alpha];
+    
+    XCTAssertEqualWithAccuracy(red, 255/255.0, 0.001,  @"Expected red value of 0, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 255/255.0, 0.001,  @"Expected green value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.001,  @"Expected blue value of 0, but got %f", blue);
+    XCTAssertEqualWithAccuracy(floor(alpha * 100)/100, 0.80, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
+    
     UIColor *redColor  = [UIColor tc_colorWithHexString:@"F00"];
     
     [redColor getRed:&red green:&green blue:&blue alpha:&alpha];
@@ -67,14 +85,14 @@
     XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.001,  @"Expected blue value of 0, but got %f", blue);
     XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
-    UIColor *otherColor  = [UIColor tc_colorWithHexString:@"#E34"];
+    UIColor *otherColor  = [UIColor tc_colorWithHexString:@"#E340"];
     
     [otherColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
     XCTAssertEqualWithAccuracy(red, 238.0/255.0, 0.001,  @"Expected red value of %f, but got %f", 238.0/255.0, red);
     XCTAssertEqualWithAccuracy(green, 51.0/255.0, 0.001,  @"Expected green value of %f, but got %f", 51.0/255.0, green);
     XCTAssertEqualWithAccuracy(blue, 68.0/255.0, 0.001,  @"Expected blue value of %f, but got %f", 68.0/255.0, blue);
-    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
+    XCTAssertEqualWithAccuracy(floor(alpha * 100)/100, 0, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
     otherColor  = [UIColor tc_colorWithHexString:@"#e34"];
     
@@ -83,7 +101,7 @@
     XCTAssertEqualWithAccuracy(red, 238.0/255.0, 0.001,  @"Expected red value of %f, but got %f", 238.0/255.0, red);
     XCTAssertEqualWithAccuracy(green, 51.0/255.0, 0.001,  @"Expected green value of %f, but got %f", 51.0/255.0, green);
     XCTAssertEqualWithAccuracy(blue, 68.0/255.0, 0.001,  @"Expected blue value of %f, but got %f", 68.0/255.0, blue);
-    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
+    XCTAssertEqualWithAccuracy(floor(alpha * 100)/100, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
     otherColor = [UIColor tc_colorWithHexString:@"c12345"];
     
@@ -92,20 +110,9 @@
     XCTAssertEqualWithAccuracy(red, 193.0/255.0, 0.001,  @"Expected red value of %f, but got %f", 193.0/255.0, red);
     XCTAssertEqualWithAccuracy(green, 35.0/255.0, 0.001,  @"Expected green value of %f, but got %f", 35.0/255.0, green);
     XCTAssertEqualWithAccuracy(blue, 69.0/255.0, 0.001,  @"Expected blue value of %f, but got %f", 69.0/255.0, blue);
-    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
-    
-    XCTAssertThrows([UIColor tc_colorWithHexString:@""]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"1"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"F"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"00"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"F000"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"#c123456"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"C123456789"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"violet"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"abcde*"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"#0123#FF"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"0123#FF"]);
+    XCTAssertEqualWithAccuracy(floor(alpha * 100)/100, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
 }
+
 
 - (void)testIsEqualToColor
 {
@@ -117,6 +124,24 @@
     color2 = [UIColor blueColor];
     
     XCTAssertFalse([color1 tc_isEqualToColor:color2]);
+}
+
+
+- (void)testIsValidHexString
+{
+    XCTAssertTrue([UIColor tc_isValidHexString:@"f123"]);
+    XCTAssertTrue([UIColor tc_isValidHexString:@"#c12"]);
+    XCTAssertTrue([UIColor tc_isValidHexString:@"C12345"]);
+    XCTAssertTrue([UIColor tc_isValidHexString:@"#0095ff80"]);
+    XCTAssertTrue([UIColor tc_isValidHexString:@"000"]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@""]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@"1"]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@"00"]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@"F"]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@"#c123456"]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@"C123456789"]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@"violet"]);
+    XCTAssertFalse([UIColor tc_isValidHexString:@"0123#FF"]);
 }
 
 @end

--- a/ThunderCatsTests/UIColorTests.m
+++ b/ThunderCatsTests/UIColorTests.m
@@ -30,100 +30,69 @@
 #import <XCTest/XCTest.h>
 #import "UIColor+TCAdditions.h"
 
-
 @interface UIColorTests : XCTestCase
 
 @end
-
 
 @implementation UIColorTests
 
 - (void)testColorWithHexString
 {
-    UIColor *color1 = [UIColor tc_colorWithHexString:@"000000"];
-    UIColor *color2 = [UIColor blackColor];
+    UIColor *blackColor = [UIColor tc_colorWithHexString:@"000"];
     
-    CGFloat r1, r2, g1, g2, b1, b2, a1, a2;
-    [color1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+    CGFloat red, green, blue, alpha;
     
-    XCTAssertTrue(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
+    [blackColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
-    color2 = [UIColor redColor];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+    XCTAssertEqualWithAccuracy(red, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", blue);
+    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
     
-    XCTAssertFalse(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
-    
-    color1 = [UIColor tc_colorWithHexString:@"FF0000"];
-    color2 = [UIColor colorWithRed:1.0 green:0 blue:0 alpha:1.0];
+    blackColor = [UIColor tc_colorWithHexString:@"#000000"];
 
-    [color1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+    [blackColor getRed:&red green:&green blue:&blue alpha:&alpha];
+
+    XCTAssertEqualWithAccuracy(red, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", blue);
+    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
     
-    XCTAssertTrue(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
+    UIColor *redColor  = [UIColor tc_colorWithHexString:@"F00"];
     
-    color2 = [UIColor blueColor];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+    [redColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
-    XCTAssertFalse(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
+    XCTAssertEqualWithAccuracy(red, 255.0/255.0, 0.05,  @"Expected red value of 1, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", blue);
+    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
     
-    color1 = [UIColor tc_colorWithHexString:@"0000FF"];
-    color2 = [UIColor colorWithHue:240.0/360.0 saturation:1.0 brightness:1.0 alpha:1.0];
+    UIColor *otherColor  = [UIColor tc_colorWithHexString:@"#E34"];
     
-    [color1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+    [otherColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
-    XCTAssertTrue(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
+    XCTAssertEqualWithAccuracy(red, 238.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 238.0/255.0, red);
+    XCTAssertEqualWithAccuracy(green, 51.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 51.0/255.0, green);
+    XCTAssertEqualWithAccuracy(blue, 68.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 68.0/255.0, blue);
+    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
     
-    color2 = [UIColor redColor];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+    otherColor = [UIColor tc_colorWithHexString:@"C12345"];
     
-    XCTAssertFalse(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
+    [otherColor getRed:&red green:&green blue:&blue alpha:&alpha];
+    
+    XCTAssertEqualWithAccuracy(red, 193.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 193.0/255.0, red);
+    XCTAssertEqualWithAccuracy(green, 35.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 35.0/255.0, green);
+    XCTAssertEqualWithAccuracy(blue, 69.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 69.0/255.0, blue);
+    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
+    
+    XCTAssertThrows([UIColor tc_colorWithHexString:@""]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"1"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"F"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"00"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"F000"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"C123456"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"C123456789"]);
 }
-
-- (void)testColorWithShortHexString
-{
-    UIColor *color1 = [UIColor tc_colorWithHexString:@"000"];
-    UIColor *color2 = [UIColor blackColor];
-    
-    CGFloat r1, r2, g1, g2, b1, b2, a1, a2;
-    [color1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-    
-    XCTAssertTrue(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
-    
-    color2 = [UIColor redColor];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-    
-    XCTAssertFalse(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
-    
-    color1 = [UIColor tc_colorWithHexString:@"F00"];
-    color2 = [UIColor colorWithRed:1.0 green:0 blue:0 alpha:1.0];
-    
-    [color1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-    
-    XCTAssertTrue(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
-    
-    color2 = [UIColor blueColor];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-    
-    XCTAssertFalse(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
-    
-    color1 = [UIColor tc_colorWithHexString:@"00F"];
-    color2 = [UIColor colorWithHue:240.0/360.0 saturation:1.0 brightness:1.0 alpha:1.0];
-    
-    [color1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-    
-    XCTAssertTrue(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
-    
-    color2 = [UIColor redColor];
-    [color2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-    
-    XCTAssertFalse(r1-r2 == 0 && g1-g2 == 0 && b1-b2 == 0 && a1-a2 == 0);
-}
-
 
 - (void)testIsEqualToColor
 {

--- a/ThunderCatsTests/UIColorTests.m
+++ b/ThunderCatsTests/UIColorTests.m
@@ -44,54 +44,67 @@
     
     [blackColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
-    XCTAssertEqualWithAccuracy(red, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", red);
-    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", green);
-    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", blue);
-    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
+    XCTAssertEqualWithAccuracy(red, 0.0/255.0, 0.001,  @"Expected red value of 0, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.001,  @"Expected green value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.001,  @"Expected blue value of 0, but got %f", blue);
+    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
     blackColor = [UIColor tc_colorWithHexString:@"#000000"];
 
     [blackColor getRed:&red green:&green blue:&blue alpha:&alpha];
 
-    XCTAssertEqualWithAccuracy(red, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", red);
-    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", green);
-    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", blue);
-    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
+    XCTAssertEqualWithAccuracy(red, 0.0/255.0, 0.001,  @"Expected red value of 0, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.001,  @"Expected green value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.001,  @"Expected blue value of 0, but got %f", blue);
+    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
     UIColor *redColor  = [UIColor tc_colorWithHexString:@"F00"];
     
     [redColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
-    XCTAssertEqualWithAccuracy(red, 255.0/255.0, 0.05,  @"Expected red value of 1, but got %f", red);
-    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", green);
-    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.05,  @"Expected red value of 0, but got %f", blue);
-    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
+    XCTAssertEqualWithAccuracy(red, 255.0/255.0, 0.001,  @"Expected red value of 1, but got %f", red);
+    XCTAssertEqualWithAccuracy(green, 0.0/255.0, 0.001,  @"Expected green value of 0, but got %f", green);
+    XCTAssertEqualWithAccuracy(blue, 0.0/255.0, 0.001,  @"Expected blue value of 0, but got %f", blue);
+    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
     UIColor *otherColor  = [UIColor tc_colorWithHexString:@"#E34"];
     
     [otherColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
-    XCTAssertEqualWithAccuracy(red, 238.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 238.0/255.0, red);
-    XCTAssertEqualWithAccuracy(green, 51.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 51.0/255.0, green);
-    XCTAssertEqualWithAccuracy(blue, 68.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 68.0/255.0, blue);
-    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
+    XCTAssertEqualWithAccuracy(red, 238.0/255.0, 0.001,  @"Expected red value of %f, but got %f", 238.0/255.0, red);
+    XCTAssertEqualWithAccuracy(green, 51.0/255.0, 0.001,  @"Expected green value of %f, but got %f", 51.0/255.0, green);
+    XCTAssertEqualWithAccuracy(blue, 68.0/255.0, 0.001,  @"Expected blue value of %f, but got %f", 68.0/255.0, blue);
+    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
-    otherColor = [UIColor tc_colorWithHexString:@"C12345"];
+    otherColor  = [UIColor tc_colorWithHexString:@"#e34"];
     
     [otherColor getRed:&red green:&green blue:&blue alpha:&alpha];
     
-    XCTAssertEqualWithAccuracy(red, 193.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 193.0/255.0, red);
-    XCTAssertEqualWithAccuracy(green, 35.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 35.0/255.0, green);
-    XCTAssertEqualWithAccuracy(blue, 69.0/255.0, 0.05,  @"Expected red value of %f, but got %f", 69.0/255.0, blue);
-    XCTAssertEqual(alpha, 1,  @"Expected red value of 1, but got %f", alpha);
+    XCTAssertEqualWithAccuracy(red, 238.0/255.0, 0.001,  @"Expected red value of %f, but got %f", 238.0/255.0, red);
+    XCTAssertEqualWithAccuracy(green, 51.0/255.0, 0.001,  @"Expected green value of %f, but got %f", 51.0/255.0, green);
+    XCTAssertEqualWithAccuracy(blue, 68.0/255.0, 0.001,  @"Expected blue value of %f, but got %f", 68.0/255.0, blue);
+    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
+    
+    otherColor = [UIColor tc_colorWithHexString:@"c12345"];
+    
+    [otherColor getRed:&red green:&green blue:&blue alpha:&alpha];
+    
+    XCTAssertEqualWithAccuracy(red, 193.0/255.0, 0.001,  @"Expected red value of %f, but got %f", 193.0/255.0, red);
+    XCTAssertEqualWithAccuracy(green, 35.0/255.0, 0.001,  @"Expected green value of %f, but got %f", 35.0/255.0, green);
+    XCTAssertEqualWithAccuracy(blue, 69.0/255.0, 0.001,  @"Expected blue value of %f, but got %f", 69.0/255.0, blue);
+    XCTAssertEqualWithAccuracy(alpha, 1, 0.001,  @"Expected alpha value of 1, but got %f", alpha);
     
     XCTAssertThrows([UIColor tc_colorWithHexString:@""]);
     XCTAssertThrows([UIColor tc_colorWithHexString:@"1"]);
     XCTAssertThrows([UIColor tc_colorWithHexString:@"F"]);
     XCTAssertThrows([UIColor tc_colorWithHexString:@"00"]);
     XCTAssertThrows([UIColor tc_colorWithHexString:@"F000"]);
-    XCTAssertThrows([UIColor tc_colorWithHexString:@"C123456"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"#c123456"]);
     XCTAssertThrows([UIColor tc_colorWithHexString:@"C123456789"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"violet"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"abcde*"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"#0123#FF"]);
+    XCTAssertThrows([UIColor tc_colorWithHexString:@"0123#FF"]);
 }
 
 - (void)testIsEqualToColor


### PR DESCRIPTION
Updated tc_isEqualToColor to use objc method and updated
tc_colorWithHexString to throw an exception for invalid hex strings.
Updated test for tc_colorWithHexString for clarity and testing if
exception is thrown for invalid hex strings.
